### PR TITLE
Replace unmaintained Rust library (Closes #53)

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -73,8 +73,8 @@
 			"github": "snaiper80",
 			"implementations": "Erlang"
 		}, {
-			"name": "Char Syam",
-			"github": "charsyam",
+			"name": "J/A",
+			"github": "archer884",
 			"implementations": "Rust"
 		}, {
 			"name": "Johannes Hildén",
@@ -574,21 +574,21 @@
 			"lib": {
 				"abbr": "rust",
 				"language": "Rust",
-				"url": "https://github.com/charsyam/hashids_rust",
+				"url": "https://github.com/archer884/harsh",
 				"links": [
 					{
 						"title": "Cargo Crate",
-						"url": "https://crates.io/crates/hashids"
+						"url": "https://crates.io/crates/harsh"
 					}
 				]
 			},
 			"author": {
-				"name": "Char Syam",
-				"twitter": "charsyam",
-				"github": "charsyam"
+				"name": "J/A",
+				"twitter": "",
+				"github": "archer884"
 			},
-			"example": "let ids_some = HashIds::new_with_salt(\"this is my salt\".to_string());\nlet ids = match ids_some {\n  Ok(v) => { v }\n  Err(e) => {\n    println!(\"error\");\n    return;\n  }\n};\nlet n: Vec<i64> = vec![1, 2, 3];\nlet id = ids.encode(&n);\nlet numbers = ids.decode(id);",
-			"download": "https://github.com/charsyam/hashids_rust/archive/master.zip"
+			"example": "let harsh = harsh::Harsh::builder().salt(\"this is my salt\").build().unwrap();\nlet id = harsh.encode(&[1, 2, 3]); // \"laHquq\"\nlet numbers = harsh.decode(id).unwrap(); // [1, 2, 3]",
+			"download": "https://github.com/archer884/harsh/archive/master.zip"
 		},
 		"haskell": {
 			"lib": {


### PR DESCRIPTION
The [`hashids`](https://crates.io/crates/hashids) crate does not seem to be maintained (see charsyam/hashids_rust#2). [`harsh`](https://github.com/archer884/harsh) is actively maintained, and seems to be the most popular replacement. 